### PR TITLE
Move sample config from readme to individual file

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,0 +1,18 @@
+{
+    "gh_server": "github.com",
+    "temp": "/home/ubuntu/jekyll-hook",
+    "scripts": {
+        "build": "./scripts/build.sh",
+        "publish": "./scripts/publish.sh"
+    },
+    "email": {
+        "user": "", 
+        "password": "", 
+        "host": "", 
+        "ssl": true
+    },
+    "accounts": [
+        "developmentseed",
+        "mapbox"
+    ]
+}

--- a/readme.md
+++ b/readme.md
@@ -12,28 +12,7 @@ A server that listens for webhook posts from GitHub, generates a website with Je
 
 Adjust `build.sh` and `publish.sh` to suit your workflow. By default, they generate a site with Jekyll and publish it to an NGINX web directory.
 
-Copy the following JSON to `config.json` in the application's root directory.
-
-```json
-{
-    "gh_server": "github.com",
-    "temp": "/home/ubuntu/jekyll-hook",
-    "scripts": {
-        "build": "./scripts/build.sh",
-        "publish": "./scripts/publish.sh"
-    },
-    "email": {
-        "user": "", 
-        "password": "", 
-        "host": "", 
-        "ssl": true
-    },
-    "accounts": [
-        "developmentseed",
-        "mapbox"
-    ]
-}
-```
+Copy `config.sample.json` to `config.json` in the root directory and customize.
 
 Configuration attributes:
 


### PR DESCRIPTION
Makes it much easier to bootstrap a new install via command line, than having to dig into the readme.
