### PR TITLE
Add in Procfile for Heroku goodness

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node jekyll-hook.js


### PR DESCRIPTION
This allows Jekyll-hook to run on heroku almost out of the box (+ config).
