### PR TITLE
Look for port in process.env, otherwise default to 8080

### DIFF
--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -82,8 +82,9 @@ app.post('/hooks/jekyll/:branch', function(req, res) {
 });
 
 // Start server
-app.listen(8080);
-console.log('Listening on port 8080');
+var port = process.env.PORT || 8080;
+app.listen(port);
+console.log('Listening on port ' + port);
 
 function run(file, params, cb) {
     var process = spawn(file, params);


### PR DESCRIPTION
This allows Heroku to properly spin up the server on a port of their choosing, while keeping the default behavior if undefined.
