### PR TITLE
Add the ability to validate the X-Hub-Signature header

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -5,6 +5,7 @@
         "build": "./scripts/build.sh",
         "publish": "./scripts/publish.sh"
     },
+    "secret": "",
     "email": {
         "user": "", 
         "password": "", 

--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -9,8 +9,32 @@ var tasks   = queue(1);
 var spawn   = require('child_process').spawn;
 var email   = require('emailjs/email');
 var mailer  = email.server.connect(config.email);
+var crypto  = require('crypto');
 
-app.use(express.bodyParser());
+app.use(express.bodyParser({
+    verify: function(req,res,buffer){
+        if(!req.headers['x-hub-signature']){
+            return;
+        }
+
+        if(!config.secret || config.secret==""){
+            console.log("Recieved a X-Hub-Signature header, but cannot validate as no secret is configured");
+            return;
+        }
+
+        var hmac = crypto.createHmac('sha1', config.secret);
+        var recieved_sig = req.headers['x-hub-signature'].split('=')[1];
+        var computed_sig = hmac.update(buffer).digest('hex');
+
+        if(recieved_sig != computed_sig){
+            console.warn('Recieved an invalid HMAC: calculated:' + computed_sig + ' != recieved:' + recieved_sig);
+            var err = new Error('Invalid Signature');
+            err.status = 403;
+            throw err;
+        }
+    }
+
+}));
 
 // Receive webhook post
 app.post('/hooks/jekyll/:branch', function(req, res) {


### PR DESCRIPTION
Github sends an X-Hub-Signature header that is a SHA1 HMAC in it's webhooks when you configure a shared secret.  This adds the ability configure a shared secret in config.json and validate incoming requests using that secret.

Because rawBody is gone, this depends on a the verify button in connect which was added in ~7 months ago (https://github.com/senchalabs/connect/pull/934/files) and so should be fairly available at this point.  
