### PR TITLE
Fix req.body.payload and double-parsing of JSON

### DIFF
--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -20,7 +20,7 @@ app.post('/hooks/jekyll/:branch', function(req, res) {
 
     // Queue request handler
     tasks.defer(function(req, res, cb) {
-        var data = JSON.parse(req.body.payload);
+        var data = req.body;
         var branch = req.params.branch;
         var params = [];
 


### PR DESCRIPTION
a) req.body.payload doesn't work anymore (JSON is directly in req.body)
b) The payload doesn't need to be JSON parsed - it's being double-parsed here, causing "Unexpected token" errors
