### PR TITLE
Adding config option for site's parent directory

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -1,6 +1,7 @@
 {
     "gh_server": "github.com",
     "temp": "/home/ubuntu/jekyll-hook",
+    "site_parent": "/usr/share/nginx/html",
     "public_repo": true,
     "scripts": {
         "build": "./scripts/build.sh",

--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -82,6 +82,8 @@ app.post('/hooks/jekyll/:branch', function(req, res) {
         /* source */ params.push(config.temp + '/' + data.owner + '/' + data.repo + '/' + data.branch + '/' + 'code');
         /* build  */ params.push(config.temp + '/' + data.owner + '/' + data.repo + '/' + data.branch + '/' + 'site');
 
+        /* site parent  */ params.push(config.site_parent);
+
         // Run build script
         run(config.scripts.build, params, function(err) {
             if (err) {

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,7 @@ Configuration attributes:
 
 - `gh_server` The GitHub server from which to pull code, e.g. github.com
 - `temp` A directory to store code and site files
+- `site_parent` Parent directory of where `_site` will be copied with the default `publish.sh`
 - `public-repo` Whether the repo is public or private (default is public)
 - `scripts`
     - `build` A script to run to build the site
@@ -83,7 +84,7 @@ that points to your jekyll-hook server `http://example.com:8080/hooks/jekyll/:br
 
 ## Configure a webserver (nginx)
 
-The default `publish.sh` is setup for nginx and copies `_site` folder to `/usr/share/nginx/html/rep_name`.
+The default `publish.sh` and `config.sample.json` are setup for nginx and copy `_site` folder to `/usr/share/nginx/html/repo_name`.
 
 If you would like to copy the website to another location, make sure to update
 nginx virtual hosts which is located at `/etc/nginx/nginx/site-available` on Ubuntu 14.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -13,7 +13,7 @@ source=$5
 build=$6
 
 # Set the path of the hosted site
-site="/usr/share/nginx/html/$repo"
+site="$7/$repo"
 
 # Remove old site files, move new ones in place
 # On amazon EC2 use sudo if nginx html forlder has root ownership


### PR DESCRIPTION
Moving the hard-coded site path from `publish.sh` to a config option.
