### PR TITLE
Handle ping

### DIFF
--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -39,6 +39,18 @@ app.use(express.bodyParser({
 // Receive webhook post
 app.post('/hooks/jekyll/:branch', function(req, res) {
 
+	var ghEvent = req.get('X-GitHub-Event');
+	if (ghEvent == 'ping') {
+		console.log('Received ping.');
+    	res.send(200);
+		return;
+	}
+	else if (ghEvent != 'push') {
+		console.log('Received unsupported event: ' + ghEvent);
+		res.send(400);
+		return;
+	}
+
     // Close connection
     res.send(202);
 

--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -39,17 +39,19 @@ app.use(express.bodyParser({
 // Receive webhook post
 app.post('/hooks/jekyll/:branch', function(req, res) {
 
-	var ghEvent = req.get('X-GitHub-Event');
-	if (ghEvent == 'ping') {
-		console.log('Received ping.');
-    	res.send(200);
-		return;
-	}
-	else if (ghEvent != 'push') {
-		console.log('Received unsupported event: ' + ghEvent);
-		res.send(400);
-		return;
-	}
+    // Ensure that we return 200 Ok on ping and an error on other requests that
+    // aren't 'push'
+    var ghEvent = req.get('X-GitHub-Event');
+    if (ghEvent == 'ping') {
+        console.log('Received ping.');
+        res.send(200);
+        return;
+    }
+    else if (ghEvent != 'push') {
+        console.log('Received unsupported event: ' + ghEvent);
+        res.send(400);
+        return;
+    }
 
     // Close connection
     res.send(202);


### PR DESCRIPTION
Handle the 'ping' event sent by GitHub as first event and also return 404 for all other events than 'push'
