### PR TITLE
Fix crash if config doesn't have an email section

### DIFF
--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -162,15 +162,13 @@ function run(file, params, cb) {
 }
 
 function send(body, subject, data) {
-    if (config.email.isActivated) {
-        if (config.email && data.pusher.email) {
-            var message = {
-                text: body,
-                from: config.email.user,
-                to: data.pusher.email,
-                subject: subject
-            };
-            mailer.send(message, function(err) { if (err) console.warn(err); });
-        }
+    if (config.email && config.email.isActivated && data.pusher.email) {
+        var message = {
+            text: body,
+            from: config.email.user,
+            to: data.pusher.email,
+            subject: subject
+        };
+        mailer.send(message, function(err) { if (err) console.warn(err); });
     }
 }


### PR DESCRIPTION
The "email" section of config.json is marked in the documentation as optional, however jekyll-hook crashes if it can't find this section.

This change fixes that bug by checking if the section exists before accessing the `email.isActivated` value, rather than afterwards.