### PR TITLE
Rerun git pull/clone in case of network caused failure

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,7 +12,8 @@ giturl=$4
 source=$5
 build=$6
 
-
+# This function retry the input command 10 times
+# in case the command returns non-zero indicating command failure
 safeRunCommand() {
 typeset cmnd="$*"
 typeset ret_code

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,15 +12,41 @@ giturl=$4
 source=$5
 build=$6
 
+
+safeRunCommand() {
+typeset cmnd="$*"
+typeset ret_code
+attempt=1
+
+echo cmnd=$cmnd
+eval $cmnd
+ret_code=$?
+while [ $ret_code != 0 ]; 
+do
+  printf "Error : [%d] when executing command: '$cmnd'" $ret_code
+
+  if [ "$attempt" -ge 10 ];
+  then
+  	exit $ret_code
+  fi
+
+  echo "Retrying"
+  echo "$attempt"
+  let attempt=$attempt+1
+  eval $cmnd
+done
+}
+
+
 # Check to see if repo exists. If not, git clone it
 if [ ! -d $source ]; then
-    git clone $giturl $source
+    safeRunCommand "git clone $giturl $source"
 fi
 
 # Git checkout appropriate branch, pull latest code
 cd $source
 git checkout $branch
-git pull origin $branch
+safeRunCommand "git pull origin $branch"
 cd -
 
 # Run jekyll


### PR DESCRIPTION
In some server environment that network condition is not that good, running git clone/pull once is not 100% certain successful. In this case, if the git command returns a non-zero value, build.sh tries to rerun this git command 10 times maximum. Otherwise, it reports error in the log.
