### PR TITLE
github no longer sends branch parameter in the request body

### DIFF
--- a/jekyll-hook.js
+++ b/jekyll-hook.js
@@ -60,7 +60,8 @@ app.post('/hooks/jekyll/*', function(req, res) {
         }
 
         // End early if not permitted branch
-        if (data.branch !== branch) {
+        branchArray = data.ref.split("/")
+        if (branchArray[branchArray.length - 1] !== branch.substring(1, branch.length)) {
             console.log('Not ' + branch + ' branch.');
             if (typeof cb === 'function') cb();
             return;


### PR DESCRIPTION
Githubs webhook request body doesn't have a branch parameter. instead they provide a refs parameter. This commit splits the ref to get the branch. 

This patch assumes your webhook is set up in the format http://myhost.com/jekyll/hook/:branchname